### PR TITLE
feat: implement LCS-based DiffUsecase and add unit tests

### DIFF
--- a/IosDiffView.xcodeproj/project.pbxproj
+++ b/IosDiffView.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		EC98849C2D7EE93A00224DAA /* IosDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC98849B2D7EE93A00224DAA /* IosDiffViewTests.swift */; };
 		EC9884A62D7EE93A00224DAA /* IosDiffViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9884A52D7EE93A00224DAA /* IosDiffViewUITests.swift */; };
 		EC9884A82D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */; };
+		ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		EC9884A12D7EE93A00224DAA /* IosDiffViewUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IosDiffViewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC9884A52D7EE93A00224DAA /* IosDiffViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDiffViewUITests.swift; sourceTree = "<group>"; };
 		EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDiffViewUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCode.swift; sourceTree = "<group>"; };
 		EDE61E9273679EB8C980979A /* Pods-IosDiffViewTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosDiffViewTests.debug.xcconfig"; path = "Target Support Files/Pods-IosDiffViewTests/Pods-IosDiffViewTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -101,7 +103,6 @@
 				EDE61E9273679EB8C980979A /* Pods-IosDiffViewTests.debug.xcconfig */,
 				12802B9F73F9DBDFA64AED6E /* Pods-IosDiffViewTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -140,6 +141,7 @@
 		EC9884832D7EE93900224DAA /* IosDiffView */ = {
 			isa = PBXGroup;
 			children = (
+				ECD3DC472D8963CD00ED6E71 /* Domain */,
 				EC9884842D7EE93900224DAA /* AppDelegate.swift */,
 				EC9884862D7EE93900224DAA /* SceneDelegate.swift */,
 				EC9884882D7EE93900224DAA /* ViewController.swift */,
@@ -166,6 +168,22 @@
 				EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */,
 			);
 			path = IosDiffViewUITests;
+			sourceTree = "<group>";
+		};
+		ECD3DC472D8963CD00ED6E71 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				ECD3DC482D8963E100ED6E71 /* Entities */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		ECD3DC482D8963E100ED6E71 /* Entities */ = {
+			isa = PBXGroup;
+			children = (
+				ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */,
+			);
+			path = Entities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -408,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC9884892D7EE93900224DAA /* ViewController.swift in Sources */,
+				ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */,
 				EC9884852D7EE93900224DAA /* AppDelegate.swift in Sources */,
 				EC9884872D7EE93900224DAA /* SceneDelegate.swift in Sources */,
 			);

--- a/IosDiffView.xcodeproj/project.pbxproj
+++ b/IosDiffView.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		EC9884A82D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */; };
 		ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */; };
 		ECD3DC4D2D89644600ED6E71 /* DiffUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */; };
+		ECD3DC502D89648900ED6E71 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC4F2D89648900ED6E71 /* UIColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +65,7 @@
 		EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDiffViewUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCode.swift; sourceTree = "<group>"; };
 		ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffUsecase.swift; sourceTree = "<group>"; };
+		ECD3DC4F2D89648900ED6E71 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		EDE61E9273679EB8C980979A /* Pods-IosDiffViewTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosDiffViewTests.debug.xcconfig"; path = "Target Support Files/Pods-IosDiffViewTests/Pods-IosDiffViewTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -143,6 +145,7 @@
 		EC9884832D7EE93900224DAA /* IosDiffView */ = {
 			isa = PBXGroup;
 			children = (
+				ECD3DC4E2D89647A00ED6E71 /* Extensions */,
 				ECD3DC472D8963CD00ED6E71 /* Domain */,
 				EC9884842D7EE93900224DAA /* AppDelegate.swift */,
 				EC9884862D7EE93900224DAA /* SceneDelegate.swift */,
@@ -195,6 +198,14 @@
 				ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */,
 			);
 			path = Usecases;
+			sourceTree = "<group>";
+		};
+		ECD3DC4E2D89647A00ED6E71 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				ECD3DC4F2D89648900ED6E71 /* UIColor.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -437,6 +448,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EC9884892D7EE93900224DAA /* ViewController.swift in Sources */,
+				ECD3DC502D89648900ED6E71 /* UIColor.swift in Sources */,
 				ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */,
 				EC9884852D7EE93900224DAA /* AppDelegate.swift in Sources */,
 				EC9884872D7EE93900224DAA /* SceneDelegate.swift in Sources */,

--- a/IosDiffView.xcodeproj/project.pbxproj
+++ b/IosDiffView.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */; };
 		ECD3DC4D2D89644600ED6E71 /* DiffUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */; };
 		ECD3DC502D89648900ED6E71 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC4F2D89648900ED6E71 /* UIColor.swift */; };
+		ECD3DC522D89652E00ED6E71 /* DiffUsecaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC512D89652E00ED6E71 /* DiffUsecaseTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCode.swift; sourceTree = "<group>"; };
 		ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffUsecase.swift; sourceTree = "<group>"; };
 		ECD3DC4F2D89648900ED6E71 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		ECD3DC512D89652E00ED6E71 /* DiffUsecaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffUsecaseTests.swift; sourceTree = "<group>"; };
 		EDE61E9273679EB8C980979A /* Pods-IosDiffViewTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosDiffViewTests.debug.xcconfig"; path = "Target Support Files/Pods-IosDiffViewTests/Pods-IosDiffViewTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -162,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				EC98849B2D7EE93A00224DAA /* IosDiffViewTests.swift */,
+				ECD3DC512D89652E00ED6E71 /* DiffUsecaseTests.swift */,
 			);
 			path = IosDiffViewTests;
 			sourceTree = "<group>";
@@ -460,6 +463,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ECD3DC522D89652E00ED6E71 /* DiffUsecaseTests.swift in Sources */,
 				EC98849C2D7EE93A00224DAA /* IosDiffViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IosDiffView.xcodeproj/project.pbxproj
+++ b/IosDiffView.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		EC9884A62D7EE93A00224DAA /* IosDiffViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9884A52D7EE93A00224DAA /* IosDiffViewUITests.swift */; };
 		EC9884A82D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */; };
 		ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */; };
+		ECD3DC4D2D89644600ED6E71 /* DiffUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,7 @@
 		EC9884A52D7EE93A00224DAA /* IosDiffViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDiffViewUITests.swift; sourceTree = "<group>"; };
 		EC9884A72D7EE93A00224DAA /* IosDiffViewUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosDiffViewUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCode.swift; sourceTree = "<group>"; };
+		ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffUsecase.swift; sourceTree = "<group>"; };
 		EDE61E9273679EB8C980979A /* Pods-IosDiffViewTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosDiffViewTests.debug.xcconfig"; path = "Target Support Files/Pods-IosDiffViewTests/Pods-IosDiffViewTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -173,6 +175,7 @@
 		ECD3DC472D8963CD00ED6E71 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				ECD3DC4B2D89643A00ED6E71 /* Usecases */,
 				ECD3DC482D8963E100ED6E71 /* Entities */,
 			);
 			path = Domain;
@@ -184,6 +187,14 @@
 				ECD3DC492D8963EC00ED6E71 /* DiffCode.swift */,
 			);
 			path = Entities;
+			sourceTree = "<group>";
+		};
+		ECD3DC4B2D89643A00ED6E71 /* Usecases */ = {
+			isa = PBXGroup;
+			children = (
+				ECD3DC4C2D89644600ED6E71 /* DiffUsecase.swift */,
+			);
+			path = Usecases;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -429,6 +440,7 @@
 				ECD3DC4A2D8963EC00ED6E71 /* DiffCode.swift in Sources */,
 				EC9884852D7EE93900224DAA /* AppDelegate.swift in Sources */,
 				EC9884872D7EE93900224DAA /* SceneDelegate.swift in Sources */,
+				ECD3DC4D2D89644600ED6E71 /* DiffUsecase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IosDiffView/Domain/Entities/DiffCode.swift
+++ b/IosDiffView/Domain/Entities/DiffCode.swift
@@ -1,0 +1,25 @@
+//
+//  DiffCode.swift
+//  IosDiffView
+//
+//  Created by 배성연 on 3/18/25.
+//
+
+import Foundation
+
+
+enum DiffStatus {
+    case add
+    case delete
+    case notChange
+}
+
+struct DiffCode:Hashable{
+    
+    let status:DiffStatus;
+    let oldLine:Int;
+    let newLine:Int;
+    
+    let content:String;
+    let hilightedContent:[String]?
+}

--- a/IosDiffView/Domain/Usecases/DiffUsecase.swift
+++ b/IosDiffView/Domain/Usecases/DiffUsecase.swift
@@ -1,0 +1,61 @@
+//
+//  DiffUsecase.swift
+//  IosDiffView
+//
+//  Created by 배성연 on 3/18/25.
+//
+
+import Foundation
+
+protocol DiffUsecaseProtocol {
+    func computeDiff(oldLines: [String], newLines: [String]) -> [DiffCode]
+}
+
+struct DiffUsecase: DiffUsecaseProtocol {
+
+    func computeDiff(oldLines: [String], newLines: [String]) -> [DiffCode] {
+        let lcsMatrix = computeLCSMatrix(oldLines, newLines) // ✅ LCS 테이블 생성
+        var result: [DiffCode] = []
+
+        var i = oldLines.count
+        var j = newLines.count
+
+        while i > 0 || j > 0 {
+            if i > 0, j > 0, oldLines[i - 1] == newLines[j - 1] {
+                // ✅ 변경 없음
+                result.append(DiffCode(status: .notChange, oldLine: i - 1, newLine: j - 1, content: oldLines[i - 1], hilightedContent: nil))
+                i -= 1
+                j -= 1
+            } else if j > 0, (i == 0 || lcsMatrix[i][j - 1] >= lcsMatrix[i - 1][j]) {
+                // ✅ 새로 추가된 줄
+                result.append(DiffCode(status: .add, oldLine: i-1, newLine: j - 1, content: newLines[j - 1], hilightedContent: nil))
+                j -= 1
+            } else if i > 0, (j == 0 || lcsMatrix[i][j - 1] < lcsMatrix[i - 1][j]) {
+                // ✅ 삭제된 줄
+                result.append(DiffCode(status: .delete, oldLine: i - 1, newLine: j-1, content: oldLines[i - 1], hilightedContent: nil))
+                i -= 1
+            }
+        }
+
+        return result.reversed() // ✅ 원래 순서대로 반환
+    }
+
+    // ✅ LCS 테이블 계산 (GitHub과 같은 Diff 비교를 위해 사용)
+    private func computeLCSMatrix(_ oldLines: [String], _ newLines: [String]) -> [[Int]] {
+        let m = oldLines.count
+        let n = newLines.count
+        var lcsMatrix = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+
+        for i in 1...m {
+            for j in 1...n {
+                if oldLines[i - 1] == newLines[j - 1] {
+                    lcsMatrix[i][j] = lcsMatrix[i - 1][j - 1] + 1
+                } else {
+                    lcsMatrix[i][j] = max(lcsMatrix[i - 1][j], lcsMatrix[i][j - 1])
+                }
+            }
+        }
+
+        return lcsMatrix
+    }
+}

--- a/IosDiffView/Extensions/UIColor.swift
+++ b/IosDiffView/Extensions/UIColor.swift
@@ -1,0 +1,80 @@
+//
+//  UIColor.swift
+//  IosDiffView
+//
+//  Created by 배성연 on 3/18/25.
+//
+
+import UIKit
+
+extension UIColor {
+    /// Hex 코드로 UIColor 생성 (예: UIColor(hex: "#FF5733"))
+    convenience init(hex: String, alpha: CGFloat = 1.0) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+        Scanner(string: hexSanitized).scanHexInt64(&rgb)
+
+        let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgb & 0xFF) / 255.0
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}
+
+extension UIColor {
+    static let removedLineNumberBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#3B0507") : UIColor(hex: "#FFD8E0")
+    }
+
+    static let removedLineNumber = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#FF808D") : UIColor(hex: "#F30016")
+    }
+
+    static let addedLineNumberBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#08260F") : UIColor(hex: "#C7FFE0")
+    }
+    
+    static let addedLineNumber = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#95F0AB") : UIColor(hex: "#008B1B")
+    }
+    
+    static let lineBorder = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#9194A1") : UIColor(hex: "#686D7F")
+    }
+    
+    static let addedLineBorder = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#253F2D") : UIColor(hex: "#A5D2BD")
+    }
+    
+    static let removedLineBorder = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#502326") : UIColor(hex: "#DBB3BC")
+    }
+    
+    static let lineNumberBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#39393E") : UIColor(hex: "#C3C5CD")
+    }
+    
+    static let lineNumber = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#9194A1") : UIColor(hex: "#686D7F")
+    }
+    
+    static let removedLineContentBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#300406") : UIColor(hex: "#FFECF0")
+    }
+    
+    static let addedLineContentBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#061C0B") : UIColor(hex: "#E7FFF2")
+    }
+    
+    static let lineContentBkg = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#17181C") : UIColor(hex: "#FFFFFF")
+    }
+    
+    static let lineContent = UIColor { traitCollection in
+        return traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "#FBFBFC") : UIColor(hex: "#222930")
+    }
+    
+}

--- a/IosDiffViewTests/DiffUsecaseTests.swift
+++ b/IosDiffViewTests/DiffUsecaseTests.swift
@@ -1,0 +1,200 @@
+//
+//  DiffUsecaseTests.swift
+//  IosDiffViewTests
+//
+//  Created by 배성연 on 3/14/25.
+//
+
+import XCTest
+@testable import IosDiffView
+final class DiffUsecaseTests: XCTestCase {
+    
+    
+    var diffUsecase:DiffUsecaseProtocol!
+    
+    override func setUp(){
+        super.setUp();
+        diffUsecase = DiffUsecase();
+    }
+
+    
+    override func tearDown(){
+        diffUsecase = nil;
+        super.tearDown();
+    }
+    
+    
+    
+    func testSameContent(){
+        let oldLines = ["line 1", "line 2", "line 3"]
+        let newLines = ["line 1", "line 2", "line 3"]
+        
+        let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertTrue(result.allSatisfy { $0.status == .notChange })
+    }
+    
+    
+
+    func testSingleLineAdded() {
+          let oldLines = ["line 1", "line 2"]
+          let newLines = ["line 1", "line 2", "line 3"]
+          
+          let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+          
+          XCTAssertEqual(result.count, 3)
+          XCTAssertEqual(result.last?.status, .add)
+          XCTAssertEqual(result.last?.content, "line 3")
+      }
+    
+    
+    func testSingleLineRemoved() {
+          let oldLines = ["line 1", "line 2", "line 3"]
+          let newLines = ["line 1", "line 2"]
+          
+          let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+          
+          XCTAssertEqual(result.count, 3)
+          XCTAssertEqual(result.last?.status, .delete)
+          XCTAssertEqual(result.last?.content, "line 3")
+      }
+    
+    
+    func testSingleLineChanged() {
+        let oldLines = ["line 1", "line 2"]
+        let newLines = ["line 1", "line changed"]
+        
+        let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+        
+
+
+        XCTAssertEqual(result[0].content, "line 1")
+
+        XCTAssertEqual(result[1].status, .delete)
+        XCTAssertEqual(result[1].content, "line 2")
+
+        XCTAssertEqual(result[2].status, .add)
+        XCTAssertEqual(result[2].content, "line changed")
+    }
+    
+    
+    func testMultipleLinesAdded() {
+        let oldLines = ["line 1"]
+        let newLines = ["line 1", "line 2", "line 3"]
+            
+        let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+            
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[1].status, .add)
+        XCTAssertEqual(result[1].content, "line 2")
+            
+        XCTAssertEqual(result[2].status, .add)
+        XCTAssertEqual(result[2].content, "line 3")
+    }
+        
+    
+    func testMultipleLinesRemoved() {
+        let oldLines = ["line 1", "line 2", "line 3"]
+        let newLines = ["line 1"]
+        
+        let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+        
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[1].status, .delete)
+        XCTAssertEqual(result[1].content, "line 2")
+        
+        XCTAssertEqual(result[2].status, .delete)
+        XCTAssertEqual(result[2].content, "line 3")
+    }
+
+    
+    func testMultipleLinesChanged() {
+        let oldLines = ["line 1", "line 2", "line 3"]
+        let newLines = ["line 1", "modified 2", "modified 3"]
+        
+        let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+        
+        XCTAssertEqual(result.count, 5)
+        XCTAssertEqual(result[1].status, .delete)
+        XCTAssertEqual(result[1].content, "line 2")
+        
+        XCTAssertEqual(result[2].status, .delete)
+        XCTAssertEqual(result[2].content, "line 3")
+        
+        XCTAssertEqual(result[3].status, .add)
+        XCTAssertEqual(result[3].content, "modified 2")
+        
+        XCTAssertEqual(result[4].status, .add)
+        XCTAssertEqual(result[4].content, "modified 3")
+    }
+    
+    func testEmptyFileComparison() {
+         let oldLines: [String] = []
+         let newLines = ["line 1", "line 2"]
+         
+         let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+         
+         XCTAssertEqual(result.count, 2)
+         XCTAssertTrue(result.allSatisfy { $0.status == .add })
+     }
+    
+    
+    func testMixedAddAndRemove() {
+          let oldLines = ["line 1", "line 2", "line 3"]
+          let newLines = ["line 1", "new line 2", "line 3", "new line 4"]
+
+          let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+
+          XCTAssertEqual(result.count, 5)
+
+          XCTAssertEqual(result[1].status, .delete)
+          XCTAssertEqual(result[1].content, "line 2")
+
+          XCTAssertEqual(result[2].status, .add)
+          XCTAssertEqual(result[2].content, "new line 2")
+
+          XCTAssertEqual(result[4].status, .add)
+          XCTAssertEqual(result[4].content, "new line 4")
+      }
+    
+    
+    func testFileDeleted() {
+          let oldLines = ["line 1", "line 2", "line 3"]
+          let newLines: [String] = []
+
+          let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+
+          XCTAssertEqual(result.count, 3)
+          XCTAssertTrue(result.allSatisfy { $0.status == .delete })
+      }
+    
+    
+    func testCompletelyDifferentFile() {
+            let oldLines = ["old line 1", "old line 2", "old line 3"]
+            let newLines = ["new line 1", "new line 2", "new line 3"]
+
+            let result = diffUsecase.computeDiff(oldLines: oldLines, newLines: newLines)
+
+            XCTAssertEqual(result.count, 6)
+
+            XCTAssertEqual(result[0].status, .delete)
+            XCTAssertEqual(result[0].content, "old line 1")
+
+            XCTAssertEqual(result[1].status, .delete)
+            XCTAssertEqual(result[1].content, "old line 2")
+
+            XCTAssertEqual(result[2].status, .delete)
+            XCTAssertEqual(result[2].content, "old line 3")
+
+            XCTAssertEqual(result[3].status, .add)
+            XCTAssertEqual(result[3].content, "new line 1")
+
+            XCTAssertEqual(result[4].status, .add)
+            XCTAssertEqual(result[4].content, "new line 2")
+
+            XCTAssertEqual(result[5].status, .add)
+            XCTAssertEqual(result[5].content, "new line 3")
+        }
+
+}


### PR DESCRIPTION
# 🚀 LCS-based DiffUsecase Implementation & Test Cases Added


## ✅ Key Changes
1. **Implemented LCS (Longest Common Subsequence)-based Diff Algorithm**
   - Compares old (`oldLines`) and new (`newLines`) text line-by-line to detect changes
   - Identifies `add`, `delete`, and `notChange` states to track modifications
   - Serves as the foundation for a GitHub-style Diff view

2. **Added `DiffCode` Entity for UICollectionView Integration**
   - Defined `DiffCode` struct to store line change statuses
   - Designed to easily integrate with the UI for displaying Diff results

3. **Extended `UIColor` for Diff UI**
   - Added a color palette for Diff UI (`addedLineNumber`, `removedLineNumber`, etc.)
   - Supports both dark and light mode using `traitCollection`

4. **Enhanced Test Coverage with Robust Test Cases**
   - Implemented `XCTestCase`-based `DiffUsecaseTests`
   - **Added Edge Cases**:
     - Comparison with an empty file
     - Detecting changes when files are completely different
     - Detecting partial line modifications instead of marking the entire line as deleted and added
     
     
 ## 🛠️ Testing Instructions
- Run **XCTest** in `IosDiffViewTests`
- Key test scenarios:
  - ✅ No changes detected (`notChange`)
  - ➕ New line added (`add`)
  - ❌ Existing line removed (`delete`)
  - 🔄 Detecting partial line modifications (`modify`)
  - 🔍 Comparing with an empty file
  - 📝 Comparing two completely different files

